### PR TITLE
Remove catches for discord API calls, so the error can propagate to individual integrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-slash-commands-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-slash-commands-client",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-slash-commands-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A simple way to interact and manage discord slash-commands",
   "main": "src/index.js",
   "types": "typings/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ const client = new interactions.Client(
   "your bots user id"
 );
 // list all your existing commands.
-client.getCommands().catch(console.error).then(console.log);
+client.getCommands().then(console.log).catch(console.error);
 
 // will create a new command and log its data. If a command with this name already exist will that be overwritten.
 client
@@ -25,8 +25,8 @@ client
     name: "unique command name",
     description: "description for this unique command",
   })
-  .catch(console.error)
-  .then(console.log);
+  .then(console.log)
+  .catch(console.error);
 
 // will edit the details of a command.
 client
@@ -34,14 +34,14 @@ client
     { name: "new command name", description: "new command description" },
     "id of the command you wish to edit"
   )
-  .catch(console.error)
-  .then(console.log);
+  .then(console.log)
+  .catch(console.error);
 
 // will delete a command
 client
   .deleteCommand("id of the command you wish to delete")
-  .catch(console.error)
-  .then(console.log);
+  .then(console.log)
+  .catch(console.error);
 ```
 
 # API
@@ -141,8 +141,8 @@ client.on("ready", () => {
       name: "ping",
       description: "ping pong",
     })
-    .catch(console.error)
-    .then(console.log);
+    .then(console.log)
+    .catch(console.error);
 });
 
 // attach and event listener for the interactionCreate event

--- a/src/core/InteractionsClient.js
+++ b/src/core/InteractionsClient.js
@@ -33,10 +33,9 @@ class InteractionsClient {
 
     if (commandID) url += `/${commandID}`;
 
-    const res = await axios
-      .get(url, { headers: { Authorization: `Bot ${this.token}` } })
-      .catch(console.error);
-    if (!res) throw "An error has occured!";
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bot ${this.token}` }
+    });
     return res.data;
   }
 
@@ -52,7 +51,6 @@ class InteractionsClient {
     const res = await axios.post(url, options, {
       headers: { Authorization: `Bot ${this.token}` },
     });
-    if (!res) throw "An error has occured!";
     return res.data;
   }
 
@@ -72,12 +70,9 @@ class InteractionsClient {
       ? `${apiUrl}/applications/${this.clientID}/guilds/${guildID}/commands/${commandID}`
       : `${apiUrl}/applications/${this.clientID}/commands/${commandID}`;
 
-    const res = await axios
-      .patch(url, options, {
-        headers: { Authorization: `Bot ${this.token}` },
-      })
-      .catch(console.error);
-    if (!res) throw "An error has occured!";
+    const res = await axios.patch(url, options, {
+      headers: { Authorization: `Bot ${this.token}` },
+    });
     return res.data;
   }
 
@@ -88,13 +83,10 @@ class InteractionsClient {
       ? `${apiUrl}/applications/${this.clientID}/guilds/${guildID}/commands/${commandID}`
       : `${apiUrl}/applications/${this.clientID}/commands/${commandID}`;
 
-    const res = await axios
-      .delete(url, {
-        headers: { Authorization: `Bot ${this.token}` },
-      })
-      .catch(console.error);
-    if (!res) throw "An error has occured!";
-    return true;
+    const res = await axios.delete(url, {
+      headers: { Authorization: `Bot ${this.token}` },
+    });
+    return res.data;
   }
 }
 


### PR DESCRIPTION
The reason for the PR is to remove the lingering `.catch()` blocks for the API requests to Discord, these `.catch()` remove the ability for developers integrating `discord-slash-commands-client` to manipulate the error response from discord - only returning "There was an error!".

After pulling in these changes, developers will be able to read/manipulate the error response object directly from discord by changing their own `.catch()` to their calls of `getCommands()`, `createCommand()`, `editCommand()`, `deleteCommand()`.