### PR TITLE
fix: Fix getCommands options and typings

### DIFF
--- a/src/core/InteractionsClient.js
+++ b/src/core/InteractionsClient.js
@@ -16,7 +16,7 @@ class InteractionsClient {
     this.clientID = clientID;
   }
 
-  async getCommands(options) {
+  async getCommands(options = {}) {
     if (typeof options !== "object")
       throw "options must be of type object. Received: " + typeof options;
     if (options.commandID && typeof options.commandID !== "string")

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,8 +42,7 @@ declare module "discord-slash-commands-client" {
     private token: string;
     private clientID: string;
     public getCommands(
-      commandID?: string,
-      guildID?: string
+      options?: getCommandsOptions
     ): Promise<ApplicationCommand[] | ApplicationCommand>;
     public createCommand(
       options: ApplicationOptions,


### PR DESCRIPTION
Currently the typings for getCommands are wrong, and the implementation fails if there is no options passed, as the README example shows. 