### PR TITLE
Adds functions for Command Permissions

### DIFF
--- a/src/core/InteractionsClient.js
+++ b/src/core/InteractionsClient.js
@@ -88,6 +88,52 @@ class InteractionsClient {
     });
     return res.data;
   }
+
+  async getCommandPermissions(guildID, commandID) {
+    if (typeof guildID !== "string")
+      throw new Error(
+        "guildID must be of type string. Received: " +
+        typeof guildID
+      );
+    if (commandID && typeof commandID !== "string")
+      throw new Error(
+        "commandID received but wasn't of type string. received: " +
+        typeof commandID
+      );
+
+    const url = commandID
+      ? `${apiUrl}/applications/${this.clientID}/guilds/${guildID}/commands/${commandID}/permissions`
+      : `${apiUrl}/applications/${this.clientID}/guilds/${guildID}/commands/permissions`;
+
+    const res = await axios.get(url, {
+      headers: { Authorization: `Bot ${this.token}` }
+    });
+
+    return res.data;
+  }
+
+  async editCommandPermissions(permissions, guildID, commandID) {
+    if (!Array.isArray(permissions))
+      throw new Error("permissions must be of type array. Received: " + typeof permissions);
+    if (typeof guildID !== "string")
+      throw new Error(
+        "guildID must be of type string. Received: " +
+        typeof guildID
+      );
+    if (typeof commandID !== "string")
+      throw new Error(
+        "commandID must be of type string. Received: " +
+        typeof commandID
+      );
+
+    const url = `${apiUrl}/applications/${this.clientID}/guilds/${guildID}/commands/${commandID}/permissions`;
+
+    const res = await axios.put(url, { permissions: permissions } , {
+      headers: { Authorization: `Bot ${this.token}` }
+    });
+
+    return res.data;
+  }
 }
 
 module.exports = InteractionsClient;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -37,22 +37,55 @@ declare module "discord-slash-commands-client" {
     options?: ApplicationCommandOption[];
   }
 
+  /**
+   * Application command permissions allow you to enable or disable commands for specific users or roles within a guild.
+   * {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissions See discord docs}
+   */
+  interface ApplicationCommandPermissions {
+    /** Id of the role or user */
+    id: string;
+
+    /** The type of permission (1 = Role, 2 = User) */
+    type: 1 | 2;
+
+    /** `true` to allow, `false` to disallow */
+    permission: boolean;
+  }
+
+  /**
+   * Returned when fetching the permissions for a command in a guild.
+   * {@link https://discord.com/developers/docs/interactions/slash-commands#guildapplicationcommandpermissions See discord docs}
+   */
+  interface GuildApplicationCommandPermissions {
+    /** Id of the command */
+    id: string;
+
+    /** Id of the application the command belongs to */
+    application_id: string;
+
+    /** Id of the guild */
+    guild_id: string;
+
+    /** Array of ApplicationCommandPermissions */
+    permissions: ApplicationCommandPermissions[];
+  }
+
   export class Client {
     constructor(token: string, clientID: string);
     private token: string;
     private clientID: string;
-    public getCommands(
-      options?: getCommandsOptions
-    ): Promise<ApplicationCommand[] | ApplicationCommand>;
-    public createCommand(
-      options: ApplicationOptions,
-      guildID?: string
-    ): Promise<ApplicationCommand>;
-    public editCommand(
-      options: ApplicationOptions,
-      commandID: string,
-      guildID?: string
-    ): Promise<ApplicationCommand>;
+    public getCommands(options?: getCommandsOptions): Promise<ApplicationCommand[] | ApplicationCommand>;
+    public createCommand(options: ApplicationOptions, guildID?: string): Promise<ApplicationCommand>;
+    public editCommand(options: ApplicationOptions, commandID: string, guildID?: string): Promise<ApplicationCommand>;
     public deleteCommand(commandID: string, guildID?: string): Promise<boolean>;
+    public getCommandPermissions(
+      guildID: string,
+      commandID?: string
+    ): Promise<GuildApplicationCommandPermissions[] | GuildApplicationCommandPermissions>;
+    public editCommandPermissions(
+      permissions: ApplicationCommandPermissions[],
+      guildID: string,
+      commandID: string
+    ): Promise<GuildApplicationCommandPermissions>;
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -74,14 +74,25 @@ declare module "discord-slash-commands-client" {
     constructor(token: string, clientID: string);
     private token: string;
     private clientID: string;
-    public getCommands(options?: getCommandsOptions): Promise<ApplicationCommand[] | ApplicationCommand>;
-    public createCommand(options: ApplicationOptions, guildID?: string): Promise<ApplicationCommand>;
-    public editCommand(options: ApplicationOptions, commandID: string, guildID?: string): Promise<ApplicationCommand>;
+    public getCommands(
+      options?: getCommandsOptions
+    ): Promise<ApplicationCommand[] | ApplicationCommand>;
+    public createCommand(
+      options: ApplicationOptions,
+      guildID?: string
+    ): Promise<ApplicationCommand>;
+    public editCommand(
+      options: ApplicationOptions,
+      commandID: string,
+      guildID?: string
+    ): Promise<ApplicationCommand>;
     public deleteCommand(commandID: string, guildID?: string): Promise<boolean>;
     public getCommandPermissions(
       guildID: string,
       commandID?: string
-    ): Promise<GuildApplicationCommandPermissions[] | GuildApplicationCommandPermissions>;
+    ): Promise<
+      GuildApplicationCommandPermissions[] | GuildApplicationCommandPermissions
+    >;
     public editCommandPermissions(
       permissions: ApplicationCommandPermissions[],
       guildID: string,


### PR DESCRIPTION
Adds `getCommandPermissions(...)` and `editCommandPermissions(...)` functions to allow management of command permissions. Also updates typings.

Example:
```js
await interactions.editCommandPermissions(
    [
        {
            id: "ROLW_ID",
            type: 1,
            permission: true
        }
    ],
    "GUILD_ID",
    "COMMAND_ID"
);

interactions.getCommandPermissions("GUILD_ID").then(console.log);
```
